### PR TITLE
SQL Syntax Error when exporting

### DIFF
--- a/ProcessExportProfile.module
+++ b/ProcessExportProfile.module
@@ -124,7 +124,7 @@ class ProcessExportProfile extends Process {
 		$this->fuel->set('processHeadline', $info['title']); 
 
 		// prevent this particular page from being copied over
-		$this->tableWhereSQL['pages'] .= ' OR id=' . $this->page->id; 
+		$this->tableWhereSQL['pages'] .= " OR id='" . $this->page->id . "'"; 
 		parent::init();
 	}
 


### PR DESCRIPTION
Ran into an error in SQL syntax when exporting. Fixed here on line 127 by wrapping $this->page->id in single quotes. 
