### PR TITLE
Add composer.json to support composer installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "ryancramerdesign/process-export-profile",
+    "type": "pw-module",
+    "description": "Enable exporting of ProcessWire 2.1 site profiles for sharing or distribution with others. ",
+    "keywords": [ "export", "import", "site", "processwire"],
+    "homepage": "http://processwire.com/",
+    "license": "GPL-2.0+",
+    "authors": [
+        {
+            "name": "Ryan Cramer",
+            "homepage": "http://processwire.com/"
+        },
+        {
+            "name": "Assets Contributors",
+            "homepage": "https://github.com/ryancramerdesign/ProcessExportProfile/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.0",
+        "hari/pw-module": "dev-master"
+    }
+}


### PR DESCRIPTION
If you add this composer.json .

People can add a composer.json in root and add

``` php
{
    "minimum-stability": "dev",
    "require": {
       "ryancramerdesign/process-export-profile": "dev-master"
    }
}
```

If `"minimum-stability": "dev",` is added it will check whether the package is stable of type. 

``` bash
php composer.phar update
```

Thoughts ?
