### PR TITLE
Added Support for custom directories in Export

### DIFF
--- a/ProcessExportProfile.module
+++ b/ProcessExportProfile.module
@@ -19,7 +19,7 @@ class ProcessExportProfile extends Process {
 		return array(
 			'title' => 'Export Site Profile', 
 			'summary' => 'Create a site profile that can be used for a fresh install of ProcessWire.', 
-			'version' => 202, 
+			'version' => 210, 
 			'icon' => 'truck', 
 			'page' => array(
 				'name' => 'export-site-profile',


### PR DESCRIPTION
@ryancramerdesign 

Whenever I use this module, I begrudgingly go back in and paste some directories from `site/assets` like my SASS or JS files - and it has bugged me for a while.

So I forked with the intent of adding support for extra files.

On the first Settings page, I added a field to type in directories to add:
![screen shot 2016-12-06 at 18 04 08](https://cloud.githubusercontent.com/assets/6864684/20947713/7870cf88-bbde-11e6-86e8-f8b3a2697bbe.png)

Those values are turned into a JSON array and passed to a new Hidden field on the `processInput` page.

On `___executeCopy()`, the array is looped through to make sure that the directories typed into Settings actually exist. If they do, they're copied.

On `executeCopyZip()`, I had to pass a second argument, which was the array of extra directories. Those are again looped through to be sure they're real, and then added to the .zip.